### PR TITLE
Variable eventCountdown establecida a su valor predeterminado al limp…

### DIFF
--- a/src/app/modules/ecoe-admin/events-schedule/events.component.ts
+++ b/src/app/modules/ecoe-admin/events-schedule/events.component.ts
@@ -357,6 +357,7 @@ export class EventsComponent implements OnInit {
 
   cleanForm(form: FormGroup): void {
     form.reset();
+    form.controls.eventCountdown.setValue(false);
     for (const key of Object.keys(form.controls)) {
       form.controls[key].markAsPristine();
       form.controls[key].updateValueAndValidity();


### PR DESCRIPTION
Solución de la congelación de la pantalla de Cronómetros al añadir Eventos. El problema era parte de la limpieza del form al cerrar el modal, no de la selección de "Sin sonido" como se creía inicialmente.