### PR TITLE
Leer apellidos por separado al importar estudiantes

### DIFF
--- a/src/app/modules/ecoe-admin/students/students.component.ts
+++ b/src/app/modules/ecoe-admin/students/students.component.ts
@@ -60,8 +60,8 @@ export class StudentsComponent implements OnInit {
 
   studentsParser: ParserFile = {
     "filename": "students.csv",
-    "fields": ["dni", "name", "surnames"],
-    "data": ["12345678A", "Name", "Surname1 Surname2"]
+    "fields": ["dni", "name", "surname1", "surname2"],
+    "data": ["12345678A", "Name", "Surname1", "Surname2"]
   };
 
   constructor(private apiService: ApiService,
@@ -357,7 +357,7 @@ export class StudentsComponent implements OnInit {
 
     for (const item of items) {
       console.log(item);
-      if (item.dni && item.name && item.surnames) {
+      if (item.dni && item.name && item.surname1 && item.surname2) {
 
         let studentPlanner: Planner = null;
         let studentPlannerOrder: number = null;
@@ -375,7 +375,7 @@ export class StudentsComponent implements OnInit {
         }
 
         savePromises.push(
-          this.newStudent(item.dni, item.name, item.surnames, studentPlannerOrder, studentPlanner)
+          this.newStudent(item.dni, item.name, item.surname1.concat(' ', item.surname2), studentPlannerOrder, studentPlanner)
             .then(result => {
               this.logPromisesOK.push(result);
               return result;
@@ -408,12 +408,10 @@ export class StudentsComponent implements OnInit {
    * @param parserResult values that was readed from file.
    */
   importStudents(parserResult: any) {
-    const students: any[] = parserResult as Array<any>;
-    if (!students[students.length - 1]['name']) {
-      students.pop();
-    }
+    const fileData: any[] = parserResult as Array<any>;
+    const students = fileData.filter(item => item['name'] !== null);
 
-    this.saveStudents(parserResult as Array<any>)
+    this.saveStudents(students)
       .then(() => {
         this.loadStudents();
       })


### PR DESCRIPTION
Cuando se importan los estudiantes a través de un CSV previamente se leían en una misma columna. Ahora cada apellido representa una columna.