### PR TITLE
Arreglado valor por defecto de preguntas de tipo rango

### DIFF
--- a/src/app/models/question.ts
+++ b/src/app/models/question.ts
@@ -114,7 +114,7 @@ export const MaxPointsRangeError = new Error('max points should be positive in R
 export class QuestionRange extends QuestionBase {
   constructor() {
     super('range');
-    this.range = 0;
+    this.range = 10;
   }
 
   range: number;


### PR DESCRIPTION
Cuando no se pone valor en el CSV en las preguntas de tipo rango es 10