### PR TITLE
Refactor organization page

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,21 +8,9 @@
     </div>
 
     <div *ngIf="userIsSuperAdmin()" style="display: inline-block;">
-      <button nz-button nz-dropdown [nzDropdownMenu]="organizaciones" style="margin: auto;" nzTrigger="click">
-        {{currentOrganization.name}}
-        <i nz-icon nzType="down"></i>
-      </button>
-
-      <nz-dropdown-menu #organizaciones="nzDropdownMenu">
-        <ul nz-menu>
-          <li *ngFor="let org of organizationList" nz-menu-item (click)="changeCurrentOrganization(org)">
-            {{org.name}}
-          </li>
-        </ul>
-      </nz-dropdown-menu>
+      <app-change-organization></app-change-organization>
     </div>
 
-  
     <app-usermenu *ngIf="isLoggedIn()" style="margin: auto;"></app-usermenu>
 
     <app-submenu *ngIf="isLoggedIn()" [submenuSelected]="'ECOE'" style="float: right;padding-right: 2em;"></app-submenu>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,7 +18,7 @@ export class AppComponent implements OnInit {
   language: string = "es";
   year: string = "";
   isCollapsed: Boolean = false;
-  visible: Boolean = false;
+  visible: boolean = false;
 
   clientHeight: number;
 
@@ -60,23 +60,8 @@ export class AppComponent implements OnInit {
     this.clientHeight = window.innerHeight;
     this.year = new Date().getFullYear().toString();
 
-    this.userService.userDataChange.subscribe(
-      (user) => {
-        this.visible = user.isSuper;
-      })
-
-    this.organizationsService.getOrganizations().then(
-      (organization) => {
-        this.organizationList = organization;
-        
-      }
-    )
-
-    this.organizationsService.currentOrganizationChange.subscribe(
-      (org) => {
-        this.currentOrganization = org;
-      }
-    )
+    this.userService.userDataChange
+      .subscribe(user => this.visible = user?.isSuper || false)
   }
 
   toCollapse(event) {
@@ -87,14 +72,7 @@ export class AppComponent implements OnInit {
     return this.authService.userLogged ? true : false;
   }
 
-  userIsSuperAdmin(): Boolean {
-    if(this.isLoggedIn()) {
-      return this.visible;
-    }
-  }
-
-  changeCurrentOrganization(selectedOrganization: Organization): void {
-    this.organizationsService.currentOrganization = selectedOrganization;
-  }
-    
+  userIsSuperAdmin(): boolean {
+    return this.isLoggedIn() ? this.visible : false;
+  }    
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -64,6 +64,7 @@ import { NzProgressModule } from "ng-zorro-antd/progress";
 import { NzSpinModule } from "ng-zorro-antd/spin";
 import { GradesComponent } from "./modules/ecoe-results/grades/grades.component";
 import { EvaluationItemsComponent } from './modules/ecoe-results/evaluation-items/evaluation-items.component';
+import { ComponentsModule } from "./components/components.module";
 
 registerLocaleData(localeEs, "es", localeEsExtra);
 
@@ -125,7 +126,8 @@ export function createTranslateLoader(http: HttpClient) {
     NzNotificationModule,
     RouterModule,
     NzSpinModule,
-    NzDropDownModule
+    NzDropDownModule,
+    ComponentsModule
   ],
   providers: [
     {

--- a/src/app/components/change-organization/change-organization/change-organization.component.html
+++ b/src/app/components/change-organization/change-organization/change-organization.component.html
@@ -1,0 +1,12 @@
+<button nz-button nz-dropdown [nzDropdownMenu]="organizationsMenu" style="margin: auto;" nzTrigger="click">
+    {{currentOrganization?.name}}
+    <i nz-icon nzType="down"></i>
+</button>
+
+<nz-dropdown-menu #organizationsMenu="nzDropdownMenu">
+    <ul nz-menu>
+        <li *ngFor="let organization of organizations" nz-menu-item (click)="changeCurrentOrganization(organization)">
+            {{organization.name}}
+        </li>
+    </ul>
+</nz-dropdown-menu>

--- a/src/app/components/change-organization/change-organization/change-organization.component.spec.ts
+++ b/src/app/components/change-organization/change-organization/change-organization.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeOrganizationComponent } from './change-organization.component';
+
+describe('ChangeOrganizationComponent', () => {
+  let component: ChangeOrganizationComponent;
+  let fixture: ComponentFixture<ChangeOrganizationComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ChangeOrganizationComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChangeOrganizationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/change-organization/change-organization/change-organization.component.ts
+++ b/src/app/components/change-organization/change-organization/change-organization.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Organization } from '@app/models';
+import { OrganizationsService } from '@app/services/organizations-service/organizations.service';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-change-organization',
+  templateUrl: './change-organization.component.html',
+  styleUrls: ['./change-organization.component.less']
+})
+export class ChangeOrganizationComponent implements OnInit, OnDestroy {
+  currentOrganization: Organization;
+  organizations: Organization[];
+
+  organizations$: Subscription;
+
+  constructor(
+    private organizationsService: OrganizationsService
+  ) { }
+
+  ngOnInit(): void {
+    this.organizationsService
+      .getOrganizations()
+      .then(organization => this.organizations = organization);
+      
+    Organization.first()
+      .then((org: Organization) => this.currentOrganization = org);
+
+    this.organizations$ = this.organizationsService 
+      .currentOrganizationChange
+      .subscribe(organization => this.currentOrganization = organization);
+  }
+
+  ngOnDestroy(): void {
+    this.organizations$.unsubscribe();
+  }
+
+  changeCurrentOrganization(selectedOrganization: Organization): void {
+    this.organizationsService.currentOrganization = selectedOrganization;
+  }
+
+}

--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { UploadAndParseComponent } from './upload-and-parse/upload-and-parse.component';
 import { ActionButtonsComponent } from './action-buttons/action-buttons.component';
-import {NzAlertModule, NzBreadCrumbModule, NzButtonModule, NzCardModule, NzDividerModule, NzDrawerModule, NzEmptyModule, NzFormModule, NzGridModule, NzIconModule, NzInputModule, NzInputNumberModule, NzLayoutModule, NzListModule, NzMenuModule, NzModalModule, NzPageHeaderModule, NzPopconfirmModule, NzProgressModule, NzRadioGroupComponent, NzRadioModule, NzRateModule, NzSelectModule, NzSkeletonModule, NzStatisticModule, NzStepsModule, NzSwitchModule, NzTableModule, NzTagModule, NzToolTipModule, NzUploadModule} from 'ng-zorro-antd';
+import {NzAlertModule, NzBreadCrumbModule, NzButtonModule, NzCardModule, NzDividerModule, NzDrawerModule, NzEmptyModule, NzFormModule, NzGridModule, NzIconModule, NzInputModule, NzInputNumberModule, NzLayoutModule, NzListModule, NzMenuModule, NzModalModule, NzPageHeaderModule, NzPopconfirmModule, NzProgressModule, NzRadioGroupComponent, NzRadioModule, NzRateModule, NzSelectModule, NzSkeletonModule, NzStatisticModule, NzStepsModule, NzSwitchModule, NzTableModule, NzTagModule, NzToolTipModule, NzUploadModule, NzDropDownModule } from 'ng-zorro-antd';
 import {TranslateModule} from '@ngx-translate/core';
 import { MenuComponent } from './menu/menu.component';
 import { DragDropModule } from '@angular/cdk/drag-drop';
@@ -20,6 +20,7 @@ import {PipesModule} from '@pipes/pipes.module';
 import { ProgressBarComponent } from './chrono/progress-bar/progress-bar.component';
 import { ChronoHeaderComponent } from './chrono/chrono-header/chrono-header.component';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { ChangeOrganizationComponent } from './change-organization/change-organization/change-organization.component';
 
 // TODO: Review to include Login and Home components
 @NgModule({
@@ -35,7 +36,8 @@ import { NzSpaceModule } from 'ng-zorro-antd/space';
     OptionsListComponent,
     ChronoComponent,
     ProgressBarComponent,
-    ChronoHeaderComponent
+    ChronoHeaderComponent,
+    ChangeOrganizationComponent
   ],
   imports: [
     CommonModule,
@@ -76,7 +78,8 @@ import { NzSpaceModule } from 'ng-zorro-antd/space';
     NzMenuModule,
     NzInputNumberModule,
     NzSpaceModule,
-    NzRadioModule
+    NzRadioModule,
+    NzDropDownModule
   ],
   exports: [
     UploadAndParseComponent,
@@ -85,7 +88,8 @@ import { NzSpaceModule } from 'ng-zorro-antd/space';
     QblockQuestionFormComponent,
     QuestionsListComponent,
     QuestionFormComponent,
-    ChronoComponent
+    ChronoComponent,
+    ChangeOrganizationComponent
   ]
 })
 export class ComponentsModule {}

--- a/src/app/components/menu/menu.component.ts
+++ b/src/app/components/menu/menu.component.ts
@@ -1,7 +1,7 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 
 @Component({
-  selector: 'app-menu',
+  selector: 'app-right-menu',
   templateUrl: './menu.component.html',
   styleUrls: ['./menu.component.less']
 })

--- a/src/app/modules/ecoe/home/home.component.ts
+++ b/src/app/modules/ecoe/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnDestroy, OnInit } from "@angular/core";
 import { debounceTime, switchMap, tap } from "rxjs/operators";
 import { FormBuilder, FormControl, FormGroup, ValidationErrors, Validators } from "@angular/forms";
 import { ApiService } from "../../../services/api/api.service";
@@ -9,7 +9,7 @@ import { ECOE } from "../../../models";
 import { UserService } from "@app/services/user/user.service";
 
 import { Router } from "@angular/router";
-import { Observable, Observer, defer, from } from "rxjs";
+import { Observable, Observer, Subscription, defer, from } from "rxjs";
 import { SharedService } from "@app/services/shared/shared.service";
 import { OrganizationsService } from "@app/services/organizations-service/organizations.service";
 
@@ -18,7 +18,7 @@ import { OrganizationsService } from "@app/services/organizations-service/organi
   templateUrl: "./home.component.html",
   styleUrls: ["./home.component.less"],
 })
-export class HomeComponent implements OnInit {
+export class HomeComponent implements OnInit, OnDestroy {
   showCreateEcoe: boolean;
   ecoesList: ECOE[];
   ecoeForm: FormControl;
@@ -31,6 +31,7 @@ export class HomeComponent implements OnInit {
   Delisted: any;
 
   validateForm!: FormGroup;
+  organizationChange$: Subscription;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -46,6 +47,9 @@ export class HomeComponent implements OnInit {
       ecoeName: ['', [Validators.required], [this.userNameAsyncValidator]],
     });
   }
+  ngOnDestroy(): void {
+    this.organizationChange$.unsubscribe();
+  }
 
   ngOnInit() {
     this.Listed = true;
@@ -55,7 +59,7 @@ export class HomeComponent implements OnInit {
   }
 
   loadEcoes(): void {
-    this.organizationsService.currentOrganizationChange
+    this.organizationChange$ = this.organizationsService.currentOrganizationChange
       .pipe(
         tap((organization: Organization) => this.organization = organization),
         switchMap(() => this.organizationsService.getEcoesByOrganization())

--- a/src/app/services/organizations-service/organizations.service.ts
+++ b/src/app/services/organizations-service/organizations.service.ts
@@ -17,8 +17,10 @@ export class OrganizationsService  {
   _init(): void {
     this.userService.userDataChange.subscribe(
       (user) => {
-        this._currentOrganization = user.user.organization;
-        this.currentOrganizationChange.next(user.user.organization);
+        if (user) {
+          this._currentOrganization = user?.user?.organization || null;
+          this.currentOrganizationChange.next(this._currentOrganization);
+        }
       })
   }
   


### PR DESCRIPTION
Hacer el componente de cambiar de organización teniendo este toda la lógica correspondiente y así que el componente App sea responsable solo de mostrarlo. También se arreglan bugs de que hacía falta refrescar la página para ver los cambios y que aun se hacían peticiones a pesar de que el usuario tenía la sesión cerrada