### PR TITLE
Usar lenguaje por defecto

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -54,7 +54,9 @@ export class AppComponent implements OnInit {
    */
   initializeTranslate() {
     this.translate.setDefaultLang(this.language);
-    this.translate.use(this.translate.getBrowserLang() || this.language);
+    let browserLanguage = this.translate.getBrowserLang();
+    let isBrowserLangAvailable = this.translate.getLangs().includes(browserLanguage);
+    this.translate.use(isBrowserLangAvailable ? browserLanguage  : this.language);
   }
 
   ngOnInit() {


### PR DESCRIPTION
Cuando el idioma del navegador del usuario no esta traducido en la aplicación, se utilizará el lenguaje por defecto de la aplicación