### PR TITLE
Hotfix/stations order

### DIFF
--- a/src/app/modules/ecoe-admin/stations/stations.component.html
+++ b/src/app/modules/ecoe-admin/stations/stations.component.html
@@ -92,9 +92,7 @@
               nzFilterOption="true"
               (nzOnSearch)="searchInSelect($event, editCache[item.id].item)"
             >
-              <!--<ng-container *ngFor="let pageOptions of selectOptions">-->
                 <nz-option *ngFor="let station of selectOptions"  [nzLabel]="station.name" [nzValue]="station"> </nz-option>
-              <!--</ng-container>-->
             </nz-select>
           </ng-container>
         </td>

--- a/src/app/modules/ecoe-admin/stations/stations.component.ts
+++ b/src/app/modules/ecoe-admin/stations/stations.component.ts
@@ -5,6 +5,7 @@ import {TranslateService} from '@ngx-translate/core';
 import {RowStation, Station, ECOE} from '../../../models';
 import {AbstractControl, FormArray, FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {getPotionID, Pagination} from '@openecoe/potion-client';
+import { NzMessageService } from 'ng-zorro-antd/message';
 
 /**
  * Component with stations and qblocks by station.
@@ -56,7 +57,8 @@ export class StationsComponent implements OnInit {
               private router: Router,
               private translate: TranslateService,
               public shared: SharedService,
-              private fb: FormBuilder) {
+              private fb: FormBuilder,
+              private message: NzMessageService) {
 
     this.stationForm = this.fb.group({
       stationRow: this.fb.array([])
@@ -236,6 +238,7 @@ export class StationsComponent implements OnInit {
       });
     }catch(err){
       console.error(err);
+      this.message.create('error', 'Error updating station');
     }
   }
 

--- a/src/app/modules/ecoe-admin/stations/stations.component.ts
+++ b/src/app/modules/ecoe-admin/stations/stations.component.ts
@@ -115,7 +115,8 @@ export class StationsComponent implements OnInit {
     }
     // deleting current station in parent stations list.
     if (excludeStation) {
-      this.selectOptions = this.selectOptions.filter(item => item.id !== excludeStation.id);
+      //this.selectOptions = this.selectOptions.filter(item => item.id !== excludeStation.id);
+      this.selectOptions = this.selectOptions.filter(item => item.order < excludeStation.order);
     }
   }
 
@@ -219,7 +220,15 @@ export class StationsComponent implements OnInit {
       return;
     }
 
+    console.log(cacheItem);
+    console.log(cacheItem.parentStation);
+    console.log(cacheItem.parentStation.order);
+    if(cacheItem.order <= cacheItem.parentStation.order) {
+      return;
+    }
+
     const body = {
+      order: cacheItem.order,
       name: cacheItem.name,
       ecoe: this.ecoeId,
       parentStation: (cacheItem.parentStation) ? cacheItem.parentStation.id : null
@@ -229,7 +238,8 @@ export class StationsComponent implements OnInit {
 
     request.then(response => {
       this.stations = this.stations.map(x => (x.id === cacheItem.id) ? response : x);
-      this.editCache[cacheItem.id].edit = false;      
+      this.editCache[cacheItem.id].edit = false;   
+      this.loadStations().finally();   
     });
   }
 

--- a/src/app/modules/ecoe-admin/stations/stations.component.ts
+++ b/src/app/modules/ecoe-admin/stations/stations.component.ts
@@ -217,7 +217,6 @@ export class StationsComponent implements OnInit {
    * @param cacheItem Resource selected
    */
   updateItem(cacheItem: any): void {
-    try{
       if (!cacheItem.name) {
         return;
       }
@@ -235,11 +234,10 @@ export class StationsComponent implements OnInit {
         this.stations = this.stations.map(x => (x.id === cacheItem.id) ? response : x);
         this.editCache[cacheItem.id].edit = false;   
         this.loadStations().finally();   
+      })
+      .catch((err) => {
+        this.message.create('error', this.translate.instant('EDIT_STATION_ERROR'));
       });
-    }catch(err){
-      console.error(err);
-      this.message.create('error', 'Error updating station');
-    }
   }
 
   /**

--- a/src/app/modules/ecoe-admin/stations/stations.component.ts
+++ b/src/app/modules/ecoe-admin/stations/stations.component.ts
@@ -215,28 +215,28 @@ export class StationsComponent implements OnInit {
    * @param cacheItem Resource selected
    */
   updateItem(cacheItem: any): void {
-    if (!cacheItem.name) {
-      return;
+    try{
+      if (!cacheItem.name) {
+        return;
+      }
+  
+      const body = {
+        order: cacheItem.order,
+        name: cacheItem.name,
+        ecoe: this.ecoeId,
+        parentStation: (cacheItem.parentStation) ? cacheItem.parentStation.id : null
+      };
+  
+      const request = cacheItem.update(body);
+  
+      request.then(response => {
+        this.stations = this.stations.map(x => (x.id === cacheItem.id) ? response : x);
+        this.editCache[cacheItem.id].edit = false;   
+        this.loadStations().finally();   
+      });
+    }catch(err){
+      console.error(err);
     }
-
-    if(cacheItem.order <= cacheItem.parentStation.order) {
-      return;
-    }
-
-    const body = {
-      order: cacheItem.order,
-      name: cacheItem.name,
-      ecoe: this.ecoeId,
-      parentStation: (cacheItem.parentStation) ? cacheItem.parentStation.id : null
-    };
-
-    const request = cacheItem.update(body);
-
-    request.then(response => {
-      this.stations = this.stations.map(x => (x.id === cacheItem.id) ? response : x);
-      this.editCache[cacheItem.id].edit = false;   
-      this.loadStations().finally();   
-    });
   }
 
   /**

--- a/src/app/modules/ecoe-admin/stations/stations.component.ts
+++ b/src/app/modules/ecoe-admin/stations/stations.component.ts
@@ -113,9 +113,8 @@ export class StationsComponent implements OnInit {
         this.selectOptions.push(new Station({name: row.name}));
       }
     }
-    // deleting current station in parent stations list.
+
     if (excludeStation) {
-      //this.selectOptions = this.selectOptions.filter(item => item.id !== excludeStation.id);
       this.selectOptions = this.selectOptions.filter(item => item.order < excludeStation.order);
     }
   }
@@ -220,9 +219,6 @@ export class StationsComponent implements OnInit {
       return;
     }
 
-    console.log(cacheItem);
-    console.log(cacheItem.parentStation);
-    console.log(cacheItem.parentStation.order);
     if(cacheItem.order <= cacheItem.parentStation.order) {
       return;
     }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -296,5 +296,6 @@
   "USERS_IMPORTED": "Usuarios importados correctamente",
   "ERROR_IMPORT_USERS": "Error importando usuarios",
   "ERRORS.ERROR_IN_QUESTION_SCHEMA": "Error en QuestionType",
-  "ECOE_CREATED": "{{name}} creada correctamente"
+  "ECOE_CREATED": "{{name}} creada correctamente",
+  "EDIT_STATION_ERROR": "El orden de la estación padre debe ser menor que la de la subestación"
 }


### PR DESCRIPTION
Arreglado a la hora de ordenar las estaciones, mostrará un mensaje de error si la estación a ordenar es menor que el orden de la estación padre.
Ahora no permite seleccionar como estación padre una estación que sea de orden mayor que la actual.