### PR TITLE
Cambio del botón pausa/continuar en los cronometros del administrador

### DIFF
--- a/src/app/modules/chrono-admin/state/state.component.html
+++ b/src/app/modules/chrono-admin/state/state.component.html
@@ -92,14 +92,18 @@
           [idEcoe]="ecoeId"
           [showDetails]="false"
           [mute]="true">
-          <nz-button-group nzSize="default">
-            <button (click)="pauseRound(round.id)" nz-button nzType="danger"><i nz-icon nzType="pause-circle" nzTheme="outline"></i>{{'PAUSE' | translate}}</button>
-            <button (click)="playRound(round.id)" nz-button nzType="primary"><i nz-icon nzType="play-circle" nzTheme="outline"></i>{{'CONTINUE' | translate}}</button>
+          <nz-button-group nzSize="default" *ngIf="ecoeStarted">
+            <ng-container *ngIf="pauses[round.id]; else pausedState">
+              <button (click)="playRound(round.id)" nz-button nzType="primary"><i nz-icon nzType="play-circle" nzTheme="outline"></i>{{'CONTINUE' | translate}}</button>
+            </ng-container>
+            <ng-template #pausedState>
+              <button (click)="pauseRound(round.id)" nz-button nzType="danger"><i nz-icon nzType="pause-circle" nzTheme="outline"></i>{{'PAUSE' | translate}}</button>
+            </ng-template>
           </nz-button-group>
         </app-chrono>
       </div>
-    </ng-container>
-  </div>
+    </ng-container>    
+  </div>  
 </nz-content>
 
 

--- a/src/app/modules/chrono-admin/state/state.component.ts
+++ b/src/app/modules/chrono-admin/state/state.component.ts
@@ -20,6 +20,7 @@ export class StateComponent implements OnInit {
   errorAlert: string;
   doSpin: boolean = false;
   changing_state: Boolean = false;
+  ecoeStarted: boolean = false;
 
   constructor(private route: ActivatedRoute,
               private translate: TranslateService,
@@ -58,16 +59,31 @@ export class StateComponent implements OnInit {
           setTimeout(() => this.errorAlert = null, 3000);
         }
       });
+      this.ecoeStarted = true;
   }
 
   pauseECOE(id: number) {
     this.chronoService.pauseECOE(id)
-      .subscribe(null, err => console.error(err));
+      .subscribe(
+        () => {
+          this.rounds.forEach(round => {
+            this.pauses[round.id] = true;
+          });
+        },
+        err => console.error(err)
+      );
   }
-
+  
   playECOE(id: number) {
     this.chronoService.playECOE(id)
-      .subscribe(null, err => console.error(err));
+      .subscribe(
+        () => {
+          this.rounds.forEach(round => {
+            this.pauses[round.id] = false;
+          });
+        },
+        err => console.error(err)
+      );
   }
 
   stopECOE(id: number) {
@@ -75,23 +91,27 @@ export class StateComponent implements OnInit {
       .subscribe(null, err => console.error(err));
 
     this.disabledBtnStart = true;
+    this.ecoeStarted = false;
 
     setTimeout(() => {
       this.disabledBtnStart = false;
       this.clearAlertError();
     }, 1000);
   }
+  pauses: { [key: number]: boolean } = {};
 
-  playRound(round: number) {
-    this.chronoService.playRound(round)
+  playRound(roundId: number) {
+    this.chronoService.playRound(roundId)
       .subscribe(null, err => console.error(err));
+    this.pauses[roundId] = false;
   }
-
+  
   pauseRound(roundId: number) {
     this.chronoService.pauseRound(roundId)
       .subscribe(null, err => console.error(err));
+    this.pauses[roundId] = true;
   }
-
+  
   clearAlertError() {
     this.errorAlert = null;
   }


### PR DESCRIPTION
Ahora los botones de continuar  y pausa, en el cronometro del administrador, se mostrará solamente uno de ellos, en vez de ambos, dependiendo del estado de cada rueda.